### PR TITLE
Bug fix on Form Data form name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## v1.2.1
+*26/06/20*
+
+* **Bug fix:** The form name was not being found in Forms > Data in admin. Well, that has been resolved!
+
+
 ## v1.2
 *19/06/20*
 

--- a/inc/class-shiftr-settings.php
+++ b/inc/class-shiftr-settings.php
@@ -7,8 +7,8 @@ class Shiftr_Settings {
     protected $shiftr_name = 'Shape Shiftr';
     protected $shiftr_url = 'https://shapeshiftr.co.uk';
 
-    private $version = '1.2';
-    private $version_date = '19/06/20'; 
+    private $version = '1.2.1';
+    private $version_date = '26/06/20'; 
 
 
     // Contact Details

--- a/inc/shiftr-form.php
+++ b/inc/shiftr-form.php
@@ -182,7 +182,7 @@ add_action( 'manage_shiftr_form_data_posts_custom_column', function( $column, $p
 
     if ( $column == 'data_from_form' ) {
 
-        $form_id = get_post_meta( $post_id, '_shiftr_form_data_form_id', true );
+        $form_id = get_post_meta( $post_id, 'shiftr_form_data_form_id', true );
 
         if ( $form_id > 0 ) {
             echo get_the_title( $form_id );
@@ -422,7 +422,7 @@ function shiftr_form_data_get_content() {
 
             ?>
             <tr>
-                <td><?= esc_html( strtoupper( $name ) ); ?></td>
+                <td><?= esc_html( strtoupper( shiftr_to_nicename( $name ) ) ); ?></td>
                 <td>
                 <?php 
 

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Theme URI: https://shapeshiftr.co.uk
 Author: Jackson Lewis
 Author URI: https://jacksonlewis.co.uk
 Description: Effortless WP theme development, ready to be shaped around your next project from the get-go.
-Version: 1.2
+Version: 1.2.1
 License: GNU General Public License & MIT
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: shapeshiftr


### PR DESCRIPTION
Fixes a bug where the form name was marked as "Unknown" when viewing the list of data under Forms > Data. Issue was caused by incorrect post meta key, previous key had a leading underscore which had since been removed.