### PR TITLE
Feature/svg colors

### DIFF
--- a/acf/shiftr-acf.php
+++ b/acf/shiftr-acf.php
@@ -108,4 +108,6 @@ if ( function_exists( 'acf_add_options_page' ) ) {
 /**  
  * Disable the ACF admin for all users.
  */
-add_filter( 'acf/settings/show_admin', '__return_false' );
+if(!current_user_can('dev')){
+    add_filter( 'acf/settings/show_admin', '__return_false' );
+ }

--- a/functions/admin.php
+++ b/functions/admin.php
@@ -97,3 +97,8 @@ function shiftr_set_display_post_states( $post_states, $post ) {
     return $post_states;
 }
 add_filter( 'display_post_states', 'shiftr_set_display_post_states', 2, 10 );
+
+/**
+ * Add "Developer" user role
+ */
+add_role( 'dev', 'Developer', get_role( 'administrator' )->capabilities );

--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -26,11 +26,3 @@
     @return unquote( "clamp(#{$min}, #{$scaler}, #{$max} )" );
 }
 
-@function encodecolor($string) {
-	@if type-of($string) == 'color' {
-        $hex: str-slice(ie-hex-str($string), 4);
-        $string:unquote("#{$hex}");
-    }
-    $string: '%23' + $string;
-	@return $string;
-}

--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -26,3 +26,11 @@
     @return unquote( "clamp(#{$min}, #{$scaler}, #{$max} )" );
 }
 
+@function encodecolor($string) {
+	@if type-of($string) == 'color' {
+        $hex: str-slice(ie-hex-str($string), 4);
+        $string:unquote("#{$hex}");
+    }
+    $string: '%23' + $string;
+	@return $string;
+}


### PR DESCRIPTION
adds function "encodecolor()" which allows you to fill svg's using color variables like below

```css
background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='48' width='48'%3E%3Cpath **fill='#{encodecolor($primary)}'** d='M24 44Q19.9 44 16.25 42.425Q12.6 40.85 9.875 38.125Q7.15 35.4 5.575 31.75Q4 28.1 4 24Q4 19.9 5.575 16.25Q7.15 12.6 9.875 9.875Q12.6 7.15 16.25 5.575Q19.9 4 24 4Q28.1 4 31.75 5.575Q35.4 7.15 38.125 9.875Q40.85 12.6 42.425 16.25Q44 19.9 44 24Q44 28.1 42.425 31.75Q40.85 35.4 38.125 38.125Q35.4 40.85 31.75 42.425Q28.1 44 24 44ZM19.15 32.5 32.5 24 19.15 15.5Z' /%3E%3C/svg%3E");
```
<img width="681" alt="Screenshot 2022-05-04 at 12 01 42" src="https://user-images.githubusercontent.com/63820393/166669382-1c735b23-487f-4fa2-89bb-cb4c4a78d2a5.png">

